### PR TITLE
Added support for prefix and file list.

### DIFF
--- a/src/Firebase.Storage/Bucket/StorageBucketList.cs
+++ b/src/Firebase.Storage/Bucket/StorageBucketList.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Firebase.Storage.Bucket
+{
+
+    public class StorageBucketList
+    {
+
+        internal StorageBucketList()
+        {
+
+        }
+
+        [JsonProperty("prefixes")]
+        public List<string> Prefixes { get; internal set; }
+
+        [JsonProperty("items")]
+        public List<StorageBucketListItem> Items { get; internal set; }
+
+        [JsonProperty("nextPageToken")]
+        public string NextPageToken { get; internal set; }
+
+    }
+
+}

--- a/src/Firebase.Storage/Bucket/StorageBucketList.cs
+++ b/src/Firebase.Storage/Bucket/StorageBucketList.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Text;
 
 namespace Firebase.Storage.Bucket
@@ -14,11 +15,20 @@ namespace Firebase.Storage.Bucket
 
         }
 
+        [JsonProperty("items")]
+        internal List<StorageBucketListItem> items { get; set; }
+
+        [JsonIgnore()]
+        public IReadOnlyList<StorageBucketListItem> Items
+        {
+            get
+            {
+                return new ReadOnlyCollection<StorageBucketListItem>(items);
+            }
+        }
+
         [JsonProperty("prefixes")]
         public List<string> Prefixes { get; internal set; }
-
-        [JsonProperty("items")]
-        public List<StorageBucketListItem> Items { get; internal set; }
 
         [JsonProperty("nextPageToken")]
         public string NextPageToken { get; internal set; }

--- a/src/Firebase.Storage/Bucket/StorageBucketListItem.cs
+++ b/src/Firebase.Storage/Bucket/StorageBucketListItem.cs
@@ -21,15 +21,49 @@ namespace Firebase.Storage.Bucket
         [JsonProperty("bucket")]
         public string Bucket { get; internal set; }
 
+        /// <summary>
+        /// Returns only the file name / directory name of the current item.
+        /// </summary>
+        /// <returns></returns>
         public string GetFilename()
         {
+            if (string.IsNullOrEmpty(Name)) return "";
+
             var i = Name.LastIndexOf("/");
             return Name.Substring(i + 1);
         }
 
+        /// <summary>
+        /// Retusn the directory path of the current item, excluding the item name.
+        /// </summary>
+        /// <returns></returns>
+        public string GetDirectory()
+        {
+            if (string.IsNullOrEmpty(Name)) return "";
+            int i = Name.LastIndexOf("/");
+
+            if (i == -1)
+            {
+                return Name;
+            }
+            else
+            {
+                return Name.Substring(0, i);
+            }
+        }
+
+        /// <summary>
+        /// Create a <see cref="FirebaseStorageReference" /> object from this item.
+        /// </summary>
+        /// <returns></returns>
         public FirebaseStorageReference GetReference()
         {
             return new FirebaseStorageReference(storage, Name);
+        }
+
+        public override string ToString()
+        {
+            return Name;
         }
 
     }

--- a/src/Firebase.Storage/Bucket/StorageBucketListItem.cs
+++ b/src/Firebase.Storage/Bucket/StorageBucketListItem.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Firebase.Storage.Bucket
+{
+    public class StorageBucketListItem
+    {
+
+        internal FirebaseStorage storage;
+
+        internal StorageBucketListItem()
+        {
+
+        }
+
+        [JsonProperty("name")]
+        public string Name { get; internal set; }
+
+        [JsonProperty("bucket")]
+        public string Bucket { get; internal set; }
+
+        public string GetFilename()
+        {
+            var i = Name.LastIndexOf("/");
+            return Name.Substring(i + 1);
+        }
+
+        public FirebaseStorageReference GetReference()
+        {
+            return new FirebaseStorageReference(storage, Name);
+        }
+
+    }
+
+}

--- a/src/Firebase.Storage/Firebase.Storage.csproj
+++ b/src/Firebase.Storage/Firebase.Storage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>FirebaseStorage.net</PackageId>
     <PackageVersion>1.0.3</PackageVersion>
     <Authors>Step Up Labs, Inc.</Authors>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Firebase.Storage/FirebaseStorage.cs
+++ b/src/Firebase.Storage/FirebaseStorage.cs
@@ -1,4 +1,9 @@
-﻿namespace Firebase.Storage
+﻿using Firebase.Storage.Bucket;
+using Newtonsoft.Json;
+using System;
+using System.Threading.Tasks;
+
+namespace Firebase.Storage
 {
     /// <summary>
     /// Entry class into firebase storage. 
@@ -34,6 +39,7 @@
             private set;
         }
 
+
         /// <summary>
         /// Constructs firebase path to the file.
         /// </summary>
@@ -49,5 +55,87 @@
         {
             return new FirebaseStorageReference(this, childRoot);
         }
+
+
+        /// <summary>
+        /// List all prefixes (folders) immediately descended from the root of the storage bucket.
+        /// </summary>
+        /// <param name="maxResults">Maximum results per page</param>
+        /// <param name="pageToken">Next page token</param>
+        /// <returns></returns>
+        public async Task<StorageBucketList> ListRootPrefixes(int maxResults = 1000, string pageToken = null) 
+            => await ListPrefixes(null, maxResults, pageToken);
+
+        /// <summary>
+        /// List all files in the storage bucket.
+        /// </summary>
+        /// <param name="maxResults">Maximum results per page</param>
+        /// <param name="pageToken">Next page token</param>
+        /// <returns></returns>
+        public async Task<StorageBucketList> ListAllFiles(int maxResults = 1000, string pageToken = null)
+            => await ListFiles(null, maxResults, pageToken);
+
+        private async Task<StorageBucketList> InternalBucketRequest(string fullUrl)
+        {
+            var cli = await Options.CreateHttpClientAsync();
+            var resp = await cli.GetAsync(fullUrl);
+
+            StorageBucketList bucket = null;
+
+            if (resp.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                var json = await resp.Content.ReadAsStringAsync();
+                var cfg = new JsonSerializerSettings()
+                {
+                    ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+                };
+
+                bucket = JsonConvert.DeserializeObject<StorageBucketList>(json, cfg);
+
+                foreach (var item in bucket.Items)
+                {
+                    item.storage = this;
+                }
+            }
+
+            return bucket;
+        }
+
+        private string GetListUrl(FirebaseStorageReference child, bool forPrefix, int maxResults = 1000, string pageToken = null)
+        {
+            if (maxResults > 1000 || maxResults < 1) throw new ArgumentOutOfRangeException(nameof(maxResults));
+
+            string path;
+            string reqUrl;
+
+            if (child != null)
+            {
+                path = child.GetEscapedPath();
+                reqUrl = $"{FirebaseStorageReference.FirebaseStorageEndpoint}{StorageBucket}/o?maxResults={maxResults}&prefix={path}%2f";
+            }
+            else
+            {
+                reqUrl = $"{FirebaseStorageReference.FirebaseStorageEndpoint}{StorageBucket}/o?maxResults={maxResults}";
+            }
+
+            if (!string.IsNullOrEmpty(pageToken))
+            {
+                reqUrl += $"&pageToken={pageToken}";
+            }
+
+            if (forPrefix) reqUrl += "&delimiter=/";
+            return reqUrl;
+        }
+
+        internal async Task<StorageBucketList> ListFiles(FirebaseStorageReference child, int maxResults = 1000, string pageToken = null)
+        {
+            return await InternalBucketRequest(GetListUrl(child, false, maxResults, pageToken));
+        }
+
+        internal async Task<StorageBucketList> ListPrefixes(FirebaseStorageReference child, int maxResults = 1000, string pageToken = null)
+        {
+            return await InternalBucketRequest(GetListUrl(child, true, maxResults, pageToken));
+        }
+
     }
 }

--- a/src/Firebase.Storage/FirebaseStorage.cs
+++ b/src/Firebase.Storage/FirebaseStorage.cs
@@ -124,20 +124,29 @@ namespace Firebase.Storage
 
             string reqUrl;
             string sb = StorageBucket.Replace(".appspot.com", "");
+            bool first = true;
 
-            reqUrl = $"{FirebaseStorageReference.FirebaseStorageEndpoint}{sb}/o?maxResults={maxResults}";
+            reqUrl = $"{FirebaseStorageReference.FirebaseStorageEndpoint}{sb}/o/?";
 
             if (child != null)
             {
-                reqUrl += $"&prefix={child.GetEscapedPath()}{Uri.EscapeDataString("/")}";
+                reqUrl += $"prefix={child.GetEscapedPath()}{Uri.EscapeDataString("/")}";
+                first = false;
             }
 
             if (!string.IsNullOrEmpty(pageToken))
             {
-                reqUrl += $"&pageToken={pageToken}";
+                if (!first) reqUrl += "&";
+                else first = false;
+
+                reqUrl += $"pageToken={pageToken}";
             }
 
+            if (!first) reqUrl += "&";
+            reqUrl += $"maxResults={maxResults}";
+
             if (forPrefix) reqUrl += "&delimiter=/";
+
             return reqUrl;
         }
 

--- a/src/Firebase.Storage/FirebaseStorage.cs
+++ b/src/Firebase.Storage/FirebaseStorage.cs
@@ -123,7 +123,7 @@ namespace Firebase.Storage
             if (maxResults > 1000 || maxResults < 1) throw new ArgumentOutOfRangeException(nameof(maxResults), "Must be a positive value between 1 and 1000 inclusive.");
 
             string reqUrl;
-            string sb = StorageBucket.Replace(".appspot.com", "");
+            string sb = StorageBucket; //.Replace(".appspot.com", "");
             bool first = true;
 
             reqUrl = $"{FirebaseStorageReference.FirebaseStorageEndpoint}{sb}/o/?";

--- a/src/Firebase.Storage/FirebaseStorageReference.cs
+++ b/src/Firebase.Storage/FirebaseStorageReference.cs
@@ -1,5 +1,6 @@
 ﻿namespace Firebase.Storage
 {
+    using Firebase.Storage.Bucket;
     using Newtonsoft.Json;
 
     using System;
@@ -10,7 +11,7 @@
 
     public class FirebaseStorageReference
     {
-        private const string FirebaseStorageEndpoint = "https://firebasestorage.googleapis.com/v0/b/";
+        internal const string FirebaseStorageEndpoint = "https://firebasestorage.googleapis.com/v0/b/";
 
         private readonly FirebaseStorage storage;
         private readonly List<string> children;
@@ -99,6 +100,24 @@
         }
 
         /// <summary>
+        /// List all files descended from this reference.
+        /// </summary>
+        /// <param name="maxResults">Maximum results per page</param>
+        /// <param name="pageToken">Next page token</param>
+        /// <returns></returns>
+        public async Task<StorageBucketList> ListFiles(int maxResults = 1000, string pageToken = null)
+            => await storage.ListFiles(this, maxResults, pageToken);
+
+        /// <summary>
+        /// List all prefixes (folders) immediately descended from this reference.
+        /// </summary>
+        /// <param name="maxResults">Maximum results per page</param>
+        /// <param name="pageToken">Next page token</param>
+        /// <returns></returns>
+        public async Task<StorageBucketList> ListPrefixes(int maxResults = 1000, string pageToken = null)
+            => await storage.ListPrefixes(this, maxResults, pageToken);
+
+        /// <summary>
         /// Constructs firebase path to the file.
         /// </summary>
         /// <param name="name"> Name of the entity. This can be folder or a file name or full path.</param>
@@ -139,22 +158,22 @@
             }
         }
 
-        private string GetTargetUrl()
+        internal string GetTargetUrl()
         {
             return $"{FirebaseStorageEndpoint}{this.storage.StorageBucket}/o?name={this.GetEscapedPath()}";
         }
 
-        private string GetDownloadUrl()
+        internal string GetDownloadUrl()
         {
             return $"{FirebaseStorageEndpoint}{this.storage.StorageBucket}/o/{this.GetEscapedPath()}";
         }
 
-        private string GetFullDownloadUrl()
+        internal string GetFullDownloadUrl()
         {
             return this.GetDownloadUrl() + "?alt=media&token=";
         }
 
-        private string GetEscapedPath()
+        internal string GetEscapedPath()
         {
             return Uri.EscapeDataString(string.Join("/", this.children));
         }

--- a/src/Firebase.Storage/FirebaseStorageReference.cs
+++ b/src/Firebase.Storage/FirebaseStorageReference.cs
@@ -102,18 +102,18 @@
         /// <summary>
         /// List all files descended from this reference.
         /// </summary>
-        /// <param name="maxResults">Maximum results per page</param>
+        /// <param name="maxResults">Maximum results per page (absolute maximum is 1000)</param>
         /// <param name="pageToken">Next page token</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="StorageBucketList" /> object with the requested results.</returns>
         public async Task<StorageBucketList> ListFiles(int maxResults = 1000, string pageToken = null)
             => await storage.ListFiles(this, maxResults, pageToken);
 
         /// <summary>
         /// List all prefixes (folders) immediately descended from this reference.
         /// </summary>
-        /// <param name="maxResults">Maximum results per page</param>
+        /// <param name="maxResults">Maximum results per page (absolute maximum is 1000)</param>
         /// <param name="pageToken">Next page token</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="StorageBucketList" /> object with the requested results.</returns>
         public async Task<StorageBucketList> ListPrefixes(int maxResults = 1000, string pageToken = null)
             => await storage.ListPrefixes(this, maxResults, pageToken);
 


### PR DESCRIPTION
The functions you want are two functions in **FirebaseStorage**: ListRootPrefixes, and ListAllFiles
Each **FirebaseStorageReference** has the functions ListPrefixes and ListFiles.  

I documented the functions in code.

One other thing. Google Cloud Storage API (upon which Firebase calls are based) has a limit of 1000 items per return, and if there's more items you get a nextPageToken.  Call the ListPrefixes and ListFiles with the pageToken returned in the last call to get the next page of results.  So to get an entire list, keep fetching until the nextPageToken is either null or the same as the last token or the total number of results is less than the maximum allowed number of results. I have documented this, somewhat, in code, as well.  If you attempt to pass a maxResults outside the range of 1-1000 you will get an **ArgumentOutOfRangeException** that I have thrown.  

```
bpass1 = await Storage.ListRootPrefixes();

foreach (var prefix in bpass1.Prefixes)
{
    bpass2 = await Storage.Child(prefix)
         .Child("models")
         .Child("model-export")
         .Child("icn")
         .ListFiles(); 

    outBucket.AddRange(bpass2.Items);
}
```